### PR TITLE
Ensure headers object in login callback can be parsed by lamba

### DIFF
--- a/src/lambda/bigcommerce_customer_login.js
+++ b/src/lambda/bigcommerce_customer_login.js
@@ -50,7 +50,7 @@ export function handler(event, context, callback) {
     callback(null, {
       statusCode: response.status,
       body: JSON.stringify(response.data),
-      headers: { CORS_HEADERS }
+      headers: { ...CORS_HEADERS }
     })
 
   // Process POST


### PR DESCRIPTION
Resolves the error decoding lambda response: error decoding lambda response: invalid type "map[string]interface {}" for "headers" key "CORS_HEADERS" returned from the customer login request.